### PR TITLE
Head Track Integration with X-Camera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(htrack VERSION 2311.1.0 LANGUAGES C CXX)
+project(htrack VERSION 2311.1.1 LANGUAGES C CXX)
 
 include(cmake/xplm.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(htrack VERSION 2209.1.2 LANGUAGES C CXX)
+project(htrack VERSION 2311.1.0 LANGUAGES C CXX)
 
 include(cmake/xplm.cmake)
 
@@ -32,7 +32,7 @@ find_xplane_sdk("${LIBACFUTILS}/SDK" 301)
 add_xplane_plugin(htrack
 
     src/main.c
-    src/htrack.c
+    src/htrack.cpp
     src/paths.c
     src/saving.c
     src/server.c

--- a/src/X-Camera.h
+++ b/src/X-Camera.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "XPLMDataAccess.h"
+#include "XPLMUtilities.h"
+
+
+/*
+* 
+
+Author: Mark Ellis
+		Stick and Rudder Studios, LLC
+		mark@StickandRudderStudios.com
+
+Current Version 1.0 Final
+
+This class implememts the interface to X-Camera's headtracking API.
+
+Call isEnabled() to determine if X-Camera is installed and currently enabled.
+
+If X-Camera is enabled then call setOffsets with the X,Y,Z, and camera rotation offsets when in a 3DCockpit or Free camera view mode.
+
+*/
+
+class HeadData
+{
+public:
+    
+    float X,Y,Z;
+    float Pitch,Yaw,Roll;
+    
+};
+
+class X_Camera
+{
+
+public:
+	X_Camera()
+	{
+
+		gXCameraStatus = nullptr;
+		gHeadTrackingPresent = nullptr;
+		gHeadTrackingX = nullptr;
+		gHeadTrackingY = nullptr;
+		gHeadTrackingZ = nullptr;
+		gHeadTrackingPitch = nullptr;
+		gHeadTrackingYaw = nullptr;
+		gHeadTrackingRoll = nullptr;
+
+		isInitialized = false;
+
+	}
+
+	bool isEnabled()
+	{
+		if (!isInitialized)
+		{
+			init();		// Get all the dataref references
+		}
+
+		if (gXCameraStatus != nullptr)	// If the X-Camera status dataref exitis then X-Camera is installed
+		{
+			int status = XPLMGetDatai(gXCameraStatus);	// Get the current status of X-Camera
+			return status & 1;	// Enabled if bit 0 is set
+		}
+
+		return false;	// No X-Camera Installed
+	}
+
+	void setOffsets(HeadData& data)
+	{
+		XPLMSetDatai(gHeadTrackingPresent, 1);		// Turn on Head Tracking and set all the offsets
+		XPLMSetDataf(gHeadTrackingX, data.X);
+		XPLMSetDataf(gHeadTrackingY, data.Y);
+		XPLMSetDataf(gHeadTrackingZ, data.Z);
+		XPLMSetDataf(gHeadTrackingPitch, data.Pitch);
+		XPLMSetDataf(gHeadTrackingYaw, data.Yaw);
+		XPLMSetDataf(gHeadTrackingRoll, data.Roll * -1.0f);	// Roll angle is backwards so multiply by -1.0
+	}
+
+private:
+
+	XPLMDataRef      gHeadTrackingPresent;
+	XPLMDataRef      gHeadTrackingX;
+	XPLMDataRef      gHeadTrackingY;
+	XPLMDataRef      gHeadTrackingZ;
+	XPLMDataRef      gHeadTrackingPitch;
+	XPLMDataRef      gHeadTrackingYaw;
+	XPLMDataRef      gHeadTrackingRoll;
+	XPLMDataRef      gXCameraStatus;
+	bool			 isInitialized;
+
+	void init()
+	{
+		gXCameraStatus = XPLMFindDataRef("SRS/X-Camera/integration/overall_status");
+		gHeadTrackingPresent = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_present");
+		gHeadTrackingX = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_x_offset");
+		gHeadTrackingY = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_y_offset");
+		gHeadTrackingZ = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_z_offset");
+		gHeadTrackingPitch = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_pitch_offset");
+		gHeadTrackingYaw = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_heading_offset");
+		gHeadTrackingRoll = XPLMFindDataRef("SRS/X-Camera/integration/headtracking_roll_offset");
+
+		XPLMDebugString("Head Track X-Camera integration is available\n");
+		isInitialized = true;
+	}
+};

--- a/src/htrack.cpp
+++ b/src/htrack.cpp
@@ -281,7 +281,7 @@ void htk_frame() {
         data.Z = 1e-2 * state.head[2];
         data.Yaw = normalize_rot(state.head[3]);
         data.Pitch = normalize_rot(state.head[4]);
-        data.Roll = normalize_rot(state.head[5]);
+        data.Roll = normalize_rot(state.head[5] * -1.0f);
         xCamera.setOffsets(data);
 
         return;

--- a/src/htrack.cpp
+++ b/src/htrack.cpp
@@ -9,6 +9,7 @@
 #include "htrack.h"
 #include "server.h"
 #include "math.h"
+#include "X-Camera.h"
 
 #include <XPLMGraphics.h>
 #include <XPLMMenus.h>
@@ -64,6 +65,8 @@ struct {
         int home;
     } menu;
 } state;
+
+X_Camera xCamera;
 
 htk_settings_t htk_settings;
 
@@ -197,7 +200,6 @@ void htk_cleanup() {
     settings_cleanup();
 }
 
-static double limits[6];
 
 void htk_plane_did_load() {
     state.must_reset = true;
@@ -238,7 +240,24 @@ void htk_frame() {
         state.head[i] -= state.neutral[i];
         if(htk_settings.axes_invert[i]) state.head[i] = -state.head[i];
     }
-    if(view_type != 1026 || !state.is_enabled) return;
+    
+    if(!state.is_enabled)
+    {
+        return;
+    }
+    else if(xCamera.isEnabled())
+    {
+        // If X-Camera is present and enabled then we need to be
+        // in either the 3D cockpit view or the free camera view (X-Camera external cameras)
+        if(view_type != 1026 && view_type != 1028)
+        {
+            return;
+        }
+    }
+    else if(view_type != 1026)
+    {
+        return;
+    }
 
     remapd3(state.head,
         limits,
@@ -253,7 +272,21 @@ void htk_frame() {
     for(int i = 0; i < 6; ++i) {
         htk_settings.sim[i] = state.head[i];
     }
+    
+    if(xCamera.isEnabled())
+    {
+        HeadData data;
+        data.X = 1e-2 * state.head[0];
+        data.Y = 1e-2 * state.head[1];
+        data.Z = 1e-2 * state.head[2];
+        data.Yaw = normalize_rot(state.head[3]);
+        data.Pitch = normalize_rot(state.head[4]);
+        data.Roll = normalize_rot(state.head[5]);
+        xCamera.setOffsets(data);
 
+        return;
+    }
+    
     dr_setf(&state.dr.head_x, 1e-2 * state.head[0] + state.viewport_ref[0]);
     dr_setf(&state.dr.head_y, 1e-2 * state.head[1] + state.viewport_ref[1]);
     dr_setf(&state.dr.head_z, 1e-2 * state.head[2] + state.viewport_ref[2]);


### PR DESCRIPTION
These code changes allow HeadTrack to coexist and integrate with X-Camera.

The file, X-Camera.h, implements the interface to X-Camera. It will allow you to efficiently test of the X-Camera plugin is installed and enabled.

The frame update code of HeadTrack has been modified to test if X-Camera is installed and enabled. If it is and the view is either 3D Cockpit or Free camera then HeadTrack will send the tracking offsets to X-Camera rather than manipulating the X-Plane pilot head datarefs directly.

Note that headtrack.c was renamed to headtrack.cpp so that a C++ compiler mode will be used to compile the X-Camera class in X-Camera.h